### PR TITLE
Make license and VCS explicit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 GPRCONFIG KB
 ============
 
-GPRCONFIG KB is a knowledge base for configuring GPR toolchains, used by
+[GPRCONFIG_KB](https://github.com/AdaCore/gprconfig_kb)
+is a knowledge base for configuring GPR toolchains, used by
 [GPRbuild](https://github.com/AdaCore/gprbuild) and
 [GPR2](https://github.com/AdaCore/gpr) projects.
 
@@ -16,3 +17,26 @@ Doc & Examples
 
 The documentation for this knowledge base  is available
 [online](http://docs.adacore.com/gprbuild-docs/html/gprbuild_ug/companion_tools.html#the-gprconfig-knowledge-base).
+
+License
+-------
+Copyright (C) 2006-2020, AdaCore
+
+This databasa is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This database is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+As a special exception under Section 7 of GPL version 3, you are
+granted additional permissions described in the GCC Runtime Library
+Exception, version 3.1, as published by the Free Software Foundation.
+
+You should have received a copy of the GNU General Public License and
+a copy of the GCC Runtime Library Exception along with this program;
+see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
+<http://www.gnu.org/licenses/>.

--- a/db/0_default.xml
+++ b/db/0_default.xml
@@ -1,4 +1,27 @@
 <?xml version="1.0" ?>
+<!--
+  Knowledge base for configuring GPRBuild and GPR2 projects.
+  Copyright (C) 2006-2020, AdaCore
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  As a special exception under Section 7 of GPL version 3, you are
+  granted additional permissions described in the GCC Runtime Library
+  Exception, version 3.1, as published by the Free Software Foundation.
+
+  You should have received a copy of the GNU General Public License and
+  a copy of the GCC Runtime Library Exception along with this program;
+  see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
+  <http://www.gnu.org/licenses/>.
+-->
 <gprconfig>
    <!--  This package provides default settings for GNAT toolchains -->
 

--- a/db/aarch64-vx7.xml
+++ b/db/aarch64-vx7.xml
@@ -1,4 +1,27 @@
 <?xml version="1.0" ?>
+<!--
+  Knowledge base for configuring GPRBuild and GPR2 projects.
+  Copyright (C) 2006-2020, AdaCore
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  As a special exception under Section 7 of GPL version 3, you are
+  granted additional permissions described in the GCC Runtime Library
+  Exception, version 3.1, as published by the Free Software Foundation.
+
+  You should have received a copy of the GNU General Public License and
+  a copy of the GCC Runtime Library Exception along with this program;
+  see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
+  <http://www.gnu.org/licenses/>.
+-->
 <!DOCTYPE gprconfig [
 <!ENTITY % env.ent SYSTEM "env.ent"> %env.ent;
 <!ENTITY % shortcuts.ent SYSTEM "shortcuts.ent"> %shortcuts.ent;

--- a/db/aarch64-vx7r2.xml
+++ b/db/aarch64-vx7r2.xml
@@ -1,4 +1,27 @@
 <?xml version="1.0" ?>
+<!--
+  Knowledge base for configuring GPRBuild and GPR2 projects.
+  Copyright (C) 2006-2020, AdaCore
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  As a special exception under Section 7 of GPL version 3, you are
+  granted additional permissions described in the GCC Runtime Library
+  Exception, version 3.1, as published by the Free Software Foundation.
+
+  You should have received a copy of the GNU General Public License and
+  a copy of the GCC Runtime Library Exception along with this program;
+  see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
+  <http://www.gnu.org/licenses/>.
+-->
 <!DOCTYPE gprconfig [
 <!ENTITY % env.ent SYSTEM "env.ent"> %env.ent;
 <!ENTITY % shortcuts.ent SYSTEM "shortcuts.ent"> %shortcuts.ent;

--- a/db/arm-vx6.xml
+++ b/db/arm-vx6.xml
@@ -1,4 +1,27 @@
 <?xml version="1.0" ?>
+<!--
+  Knowledge base for configuring GPRBuild and GPR2 projects.
+  Copyright (C) 2006-2020, AdaCore
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  As a special exception under Section 7 of GPL version 3, you are
+  granted additional permissions described in the GCC Runtime Library
+  Exception, version 3.1, as published by the Free Software Foundation.
+
+  You should have received a copy of the GNU General Public License and
+  a copy of the GCC Runtime Library Exception along with this program;
+  see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
+  <http://www.gnu.org/licenses/>.
+-->
 <!DOCTYPE gprconfig [
 <!ENTITY % env.ent SYSTEM "env.ent"> %env.ent;
 <!ENTITY % shortcuts.ent SYSTEM "shortcuts.ent"> %shortcuts.ent;

--- a/db/arm-vx7.xml
+++ b/db/arm-vx7.xml
@@ -1,4 +1,27 @@
 <?xml version="1.0" ?>
+<!--
+  Knowledge base for configuring GPRBuild and GPR2 projects.
+  Copyright (C) 2006-2020, AdaCore
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  As a special exception under Section 7 of GPL version 3, you are
+  granted additional permissions described in the GCC Runtime Library
+  Exception, version 3.1, as published by the Free Software Foundation.
+
+  You should have received a copy of the GNU General Public License and
+  a copy of the GCC Runtime Library Exception along with this program;
+  see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
+  <http://www.gnu.org/licenses/>.
+-->
 <!DOCTYPE gprconfig [
 <!ENTITY % env.ent SYSTEM "env.ent"> %env.ent;
 <!ENTITY % shortcuts.ent SYSTEM "shortcuts.ent"> %shortcuts.ent;

--- a/db/arm-vx7r2.xml
+++ b/db/arm-vx7r2.xml
@@ -1,4 +1,27 @@
 <?xml version="1.0" ?>
+<!--
+  Knowledge base for configuring GPRBuild and GPR2 projects.
+  Copyright (C) 2006-2020, AdaCore
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  As a special exception under Section 7 of GPL version 3, you are
+  granted additional permissions described in the GCC Runtime Library
+  Exception, version 3.1, as published by the Free Software Foundation.
+
+  You should have received a copy of the GNU General Public License and
+  a copy of the GCC Runtime Library Exception along with this program;
+  see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
+  <http://www.gnu.org/licenses/>.
+-->
 <!DOCTYPE gprconfig [
 <!ENTITY % env.ent SYSTEM "env.ent"> %env.ent;
 <!ENTITY % shortcuts.ent SYSTEM "shortcuts.ent"> %shortcuts.ent;

--- a/db/asis.xml
+++ b/db/asis.xml
@@ -1,4 +1,27 @@
 <?xml version="1.0" ?>
+<!--
+  Knowledge base for configuring GPRBuild and GPR2 projects.
+  Copyright (C) 2006-2020, AdaCore
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  As a special exception under Section 7 of GPL version 3, you are
+  granted additional permissions described in the GCC Runtime Library
+  Exception, version 3.1, as published by the Free Software Foundation.
+
+  You should have received a copy of the GNU General Public License and
+  a copy of the GCC Runtime Library Exception along with this program;
+  see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
+  <http://www.gnu.org/licenses/>.
+-->
 
 <gprconfig>
 

--- a/db/asm.xml
+++ b/db/asm.xml
@@ -1,4 +1,27 @@
 <?xml version="1.0" ?>
+<!--
+  Knowledge base for configuring GPRBuild and GPR2 projects.
+  Copyright (C) 2006-2020, AdaCore
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  As a special exception under Section 7 of GPL version 3, you are
+  granted additional permissions described in the GCC Runtime Library
+  Exception, version 3.1, as published by the Free Software Foundation.
+
+  You should have received a copy of the GNU General Public License and
+  a copy of the GCC Runtime Library Exception along with this program;
+  see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
+  <http://www.gnu.org/licenses/>.
+-->
 <gprconfig>
    <!--  This package provides the default standard options for a gcc
          Asm compiler -->

--- a/db/baselined.xml
+++ b/db/baselined.xml
@@ -1,4 +1,27 @@
 <?xml version="1.0" ?>
+<!--
+  Knowledge base for configuring GPRBuild and GPR2 projects.
+  Copyright (C) 2006-2020, AdaCore
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  As a special exception under Section 7 of GPL version 3, you are
+  granted additional permissions described in the GCC Runtime Library
+  Exception, version 3.1, as published by the Free Software Foundation.
+
+  You should have received a copy of the GNU General Public License and
+  a copy of the GCC Runtime Library Exception along with this program;
+  see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
+  <http://www.gnu.org/licenses/>.
+-->
 
 <gprconfig>
 

--- a/db/bin_img.xml
+++ b/db/bin_img.xml
@@ -1,4 +1,27 @@
 <?xml version="1.0" ?>
+<!--
+  Knowledge base for configuring GPRBuild and GPR2 projects.
+  Copyright (C) 2006-2020, AdaCore
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  As a special exception under Section 7 of GPL version 3, you are
+  granted additional permissions described in the GCC Runtime Library
+  Exception, version 3.1, as published by the Free Software Foundation.
+
+  You should have received a copy of the GNU General Public License and
+  a copy of the GCC Runtime Library Exception along with this program;
+  see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
+  <http://www.gnu.org/licenses/>.
+-->
 <gprconfig>
    <!--  This package provides the default standard options for binary image embedding -->
 

--- a/db/c.xml
+++ b/db/c.xml
@@ -1,4 +1,27 @@
 <?xml version="1.0" ?>
+<!--
+  Knowledge base for configuring GPRBuild and GPR2 projects.
+  Copyright (C) 2006-2020, AdaCore
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  As a special exception under Section 7 of GPL version 3, you are
+  granted additional permissions described in the GCC Runtime Library
+  Exception, version 3.1, as published by the Free Software Foundation.
+
+  You should have received a copy of the GNU General Public License and
+  a copy of the GCC Runtime Library Exception along with this program;
+  see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
+  <http://www.gnu.org/licenses/>.
+-->
 <gprconfig>
    <!--  This package provides the default standard options for a gcc
          C compiler -->

--- a/db/clean.xml
+++ b/db/clean.xml
@@ -1,4 +1,27 @@
 <?xml version="1.0" ?>
+<!--
+  Knowledge base for configuring GPRBuild and GPR2 projects.
+  Copyright (C) 2006-2020, AdaCore
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  As a special exception under Section 7 of GPL version 3, you are
+  granted additional permissions described in the GCC Runtime Library
+  Exception, version 3.1, as published by the Free Software Foundation.
+
+  You should have received a copy of the GNU General Public License and
+  a copy of the GCC Runtime Library Exception along with this program;
+  see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
+  <http://www.gnu.org/licenses/>.
+-->
 
 <gprconfig>
    <configuration>

--- a/db/compilers-arm-vx7.xml
+++ b/db/compilers-arm-vx7.xml
@@ -1,4 +1,27 @@
 <?xml version="1.0" ?>
+<!--
+  Knowledge base for configuring GPRBuild and GPR2 projects.
+  Copyright (C) 2006-2020, AdaCore
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  As a special exception under Section 7 of GPL version 3, you are
+  granted additional permissions described in the GCC Runtime Library
+  Exception, version 3.1, as published by the Free Software Foundation.
+
+  You should have received a copy of the GNU General Public License and
+  a copy of the GCC Runtime Library Exception along with this program;
+  see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
+  <http://www.gnu.org/licenses/>.
+-->
 <!DOCTYPE gprconfig [
 <!ENTITY % env.ent SYSTEM "env.ent"> %env.ent;
 <!ENTITY % shortcuts.ent SYSTEM "shortcuts.ent"> %shortcuts.ent;

--- a/db/compilers-asis.xml
+++ b/db/compilers-asis.xml
@@ -1,4 +1,27 @@
 <?xml version="1.0" ?>
+<!--
+  Knowledge base for configuring GPRBuild and GPR2 projects.
+  Copyright (C) 2006-2020, AdaCore
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  As a special exception under Section 7 of GPL version 3, you are
+  granted additional permissions described in the GCC Runtime Library
+  Exception, version 3.1, as published by the Free Software Foundation.
+
+  You should have received a copy of the GNU General Public License and
+  a copy of the GCC Runtime Library Exception along with this program;
+  see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
+  <http://www.gnu.org/licenses/>.
+-->
 
 <gprconfig>
 

--- a/db/compilers-baselined.xml
+++ b/db/compilers-baselined.xml
@@ -1,4 +1,27 @@
 <?xml version="1.0" ?>
+<!--
+  Knowledge base for configuring GPRBuild and GPR2 projects.
+  Copyright (C) 2006-2020, AdaCore
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  As a special exception under Section 7 of GPL version 3, you are
+  granted additional permissions described in the GCC Runtime Library
+  Exception, version 3.1, as published by the Free Software Foundation.
+
+  You should have received a copy of the GNU General Public License and
+  a copy of the GCC Runtime Library Exception along with this program;
+  see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
+  <http://www.gnu.org/licenses/>.
+-->
 <gprconfig>
 
    <!-- G++ for WRS Linux -->

--- a/db/compilers-e500v2-vx6.xml
+++ b/db/compilers-e500v2-vx6.xml
@@ -1,4 +1,27 @@
 <?xml version="1.0" ?>
+<!--
+  Knowledge base for configuring GPRBuild and GPR2 projects.
+  Copyright (C) 2006-2020, AdaCore
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  As a special exception under Section 7 of GPL version 3, you are
+  granted additional permissions described in the GCC Runtime Library
+  Exception, version 3.1, as published by the Free Software Foundation.
+
+  You should have received a copy of the GNU General Public License and
+  a copy of the GCC Runtime Library Exception along with this program;
+  see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
+  <http://www.gnu.org/licenses/>.
+-->
 <!DOCTYPE gprconfig [
 <!ENTITY % env.ent SYSTEM "env.ent"> %env.ent;
 <!ENTITY % shortcuts.ent SYSTEM "shortcuts.ent"> %shortcuts.ent;

--- a/db/compilers-e500v2-vx653.xml
+++ b/db/compilers-e500v2-vx653.xml
@@ -1,4 +1,27 @@
 <?xml version="1.0" ?>
+<!--
+  Knowledge base for configuring GPRBuild and GPR2 projects.
+  Copyright (C) 2006-2020, AdaCore
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  As a special exception under Section 7 of GPL version 3, you are
+  granted additional permissions described in the GCC Runtime Library
+  Exception, version 3.1, as published by the Free Software Foundation.
+
+  You should have received a copy of the GNU General Public License and
+  a copy of the GCC Runtime Library Exception along with this program;
+  see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
+  <http://www.gnu.org/licenses/>.
+-->
 <!DOCTYPE gprconfig [
 <!ENTITY % env.ent SYSTEM "env.ent"> %env.ent;
 <!ENTITY % shortcuts.ent SYSTEM "shortcuts.ent"> %shortcuts.ent;

--- a/db/compilers-e500v2-vx7.xml
+++ b/db/compilers-e500v2-vx7.xml
@@ -1,4 +1,27 @@
 <?xml version="1.0" ?>
+<!--
+  Knowledge base for configuring GPRBuild and GPR2 projects.
+  Copyright (C) 2006-2020, AdaCore
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  As a special exception under Section 7 of GPL version 3, you are
+  granted additional permissions described in the GCC Runtime Library
+  Exception, version 3.1, as published by the Free Software Foundation.
+
+  You should have received a copy of the GNU General Public License and
+  a copy of the GCC Runtime Library Exception along with this program;
+  see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
+  <http://www.gnu.org/licenses/>.
+-->
 <!DOCTYPE gprconfig [
 <!ENTITY % env.ent SYSTEM "env.ent"> %env.ent;
 <!ENTITY % shortcuts.ent SYSTEM "shortcuts.ent"> %shortcuts.ent;

--- a/db/compilers-e500v2-vx7r2.xml
+++ b/db/compilers-e500v2-vx7r2.xml
@@ -1,4 +1,27 @@
 <?xml version="1.0" ?>
+<!--
+  Knowledge base for configuring GPRBuild and GPR2 projects.
+  Copyright (C) 2006-2020, AdaCore
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  As a special exception under Section 7 of GPL version 3, you are
+  granted additional permissions described in the GCC Runtime Library
+  Exception, version 3.1, as published by the Free Software Foundation.
+
+  You should have received a copy of the GNU General Public License and
+  a copy of the GCC Runtime Library Exception along with this program;
+  see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
+  <http://www.gnu.org/licenses/>.
+-->
 <!DOCTYPE gprconfig [
 <!ENTITY % env.ent SYSTEM "env.ent"> %env.ent;
 <!ENTITY % shortcuts.ent SYSTEM "shortcuts.ent"> %shortcuts.ent;

--- a/db/compilers-ppc-vx653.xml
+++ b/db/compilers-ppc-vx653.xml
@@ -1,4 +1,27 @@
 <?xml version="1.0" ?>
+<!--
+  Knowledge base for configuring GPRBuild and GPR2 projects.
+  Copyright (C) 2006-2020, AdaCore
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  As a special exception under Section 7 of GPL version 3, you are
+  granted additional permissions described in the GCC Runtime Library
+  Exception, version 3.1, as published by the Free Software Foundation.
+
+  You should have received a copy of the GNU General Public License and
+  a copy of the GCC Runtime Library Exception along with this program;
+  see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
+  <http://www.gnu.org/licenses/>.
+-->
 <!DOCTYPE gprconfig [
 <!ENTITY % env.ent SYSTEM "env.ent"> %env.ent;
 <!ENTITY % shortcuts.ent SYSTEM "shortcuts.ent"> %shortcuts.ent;

--- a/db/compilers-ppc-vx7.xml
+++ b/db/compilers-ppc-vx7.xml
@@ -1,4 +1,27 @@
 <?xml version="1.0" ?>
+<!--
+  Knowledge base for configuring GPRBuild and GPR2 projects.
+  Copyright (C) 2006-2020, AdaCore
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  As a special exception under Section 7 of GPL version 3, you are
+  granted additional permissions described in the GCC Runtime Library
+  Exception, version 3.1, as published by the Free Software Foundation.
+
+  You should have received a copy of the GNU General Public License and
+  a copy of the GCC Runtime Library Exception along with this program;
+  see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
+  <http://www.gnu.org/licenses/>.
+-->
 <!DOCTYPE gprconfig [
 <!ENTITY % env.ent SYSTEM "env.ent"> %env.ent;
 <!ENTITY % shortcuts.ent SYSTEM "shortcuts.ent"> %shortcuts.ent;

--- a/db/compilers-ppc-vx7r2.xml
+++ b/db/compilers-ppc-vx7r2.xml
@@ -1,4 +1,27 @@
 <?xml version="1.0" ?>
+<!--
+  Knowledge base for configuring GPRBuild and GPR2 projects.
+  Copyright (C) 2006-2020, AdaCore
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  As a special exception under Section 7 of GPL version 3, you are
+  granted additional permissions described in the GCC Runtime Library
+  Exception, version 3.1, as published by the Free Software Foundation.
+
+  You should have received a copy of the GNU General Public License and
+  a copy of the GCC Runtime Library Exception along with this program;
+  see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
+  <http://www.gnu.org/licenses/>.
+-->
 <!DOCTYPE gprconfig [
 <!ENTITY % env.ent SYSTEM "env.ent"> %env.ent;
 <!ENTITY % shortcuts.ent SYSTEM "shortcuts.ent"> %shortcuts.ent;

--- a/db/compilers-ppc64-vx7.xml
+++ b/db/compilers-ppc64-vx7.xml
@@ -1,4 +1,27 @@
 <?xml version="1.0" ?>
+<!--
+  Knowledge base for configuring GPRBuild and GPR2 projects.
+  Copyright (C) 2006-2020, AdaCore
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  As a special exception under Section 7 of GPL version 3, you are
+  granted additional permissions described in the GCC Runtime Library
+  Exception, version 3.1, as published by the Free Software Foundation.
+
+  You should have received a copy of the GNU General Public License and
+  a copy of the GCC Runtime Library Exception along with this program;
+  see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
+  <http://www.gnu.org/licenses/>.
+-->
 <!DOCTYPE gprconfig [
 <!ENTITY % env.ent SYSTEM "env.ent"> %env.ent;
 <!ENTITY % shortcuts.ent SYSTEM "shortcuts.ent"> %shortcuts.ent;

--- a/db/compilers-ppc64-vx7r2.xml
+++ b/db/compilers-ppc64-vx7r2.xml
@@ -1,4 +1,27 @@
 <?xml version="1.0" ?>
+<!--
+  Knowledge base for configuring GPRBuild and GPR2 projects.
+  Copyright (C) 2006-2020, AdaCore
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  As a special exception under Section 7 of GPL version 3, you are
+  granted additional permissions described in the GCC Runtime Library
+  Exception, version 3.1, as published by the Free Software Foundation.
+
+  You should have received a copy of the GNU General Public License and
+  a copy of the GCC Runtime Library Exception along with this program;
+  see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
+  <http://www.gnu.org/licenses/>.
+-->
 <!DOCTYPE gprconfig [
 <!ENTITY % env.ent SYSTEM "env.ent"> %env.ent;
 <!ENTITY % shortcuts.ent SYSTEM "shortcuts.ent"> %shortcuts.ent;

--- a/db/compilers-vxworks.xml
+++ b/db/compilers-vxworks.xml
@@ -1,4 +1,27 @@
 <?xml version="1.0" ?>
+<!--
+  Knowledge base for configuring GPRBuild and GPR2 projects.
+  Copyright (C) 2006-2020, AdaCore
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  As a special exception under Section 7 of GPL version 3, you are
+  granted additional permissions described in the GCC Runtime Library
+  Exception, version 3.1, as published by the Free Software Foundation.
+
+  You should have received a copy of the GNU General Public License and
+  a copy of the GCC Runtime Library Exception along with this program;
+  see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
+  <http://www.gnu.org/licenses/>.
+-->
 <!DOCTYPE gprconfig [
 <!ENTITY % env.ent SYSTEM "env.ent"> %env.ent;
 <!ENTITY % shortcuts.ent SYSTEM "shortcuts.ent"> %shortcuts.ent;

--- a/db/compilers-x86-vx7.xml
+++ b/db/compilers-x86-vx7.xml
@@ -1,4 +1,27 @@
 <?xml version="1.0" ?>
+<!--
+  Knowledge base for configuring GPRBuild and GPR2 projects.
+  Copyright (C) 2006-2020, AdaCore
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  As a special exception under Section 7 of GPL version 3, you are
+  granted additional permissions described in the GCC Runtime Library
+  Exception, version 3.1, as published by the Free Software Foundation.
+
+  You should have received a copy of the GNU General Public License and
+  a copy of the GCC Runtime Library Exception along with this program;
+  see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
+  <http://www.gnu.org/licenses/>.
+-->
 <!DOCTYPE gprconfig [
 <!ENTITY % env.ent SYSTEM "env.ent"> %env.ent;
 <!ENTITY % shortcuts.ent SYSTEM "shortcuts.ent"> %shortcuts.ent;

--- a/db/compilers-x86_64-vx7.xml
+++ b/db/compilers-x86_64-vx7.xml
@@ -1,4 +1,27 @@
 <?xml version="1.0" ?>
+<!--
+  Knowledge base for configuring GPRBuild and GPR2 projects.
+  Copyright (C) 2006-2020, AdaCore
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  As a special exception under Section 7 of GPL version 3, you are
+  granted additional permissions described in the GCC Runtime Library
+  Exception, version 3.1, as published by the Free Software Foundation.
+
+  You should have received a copy of the GNU General Public License and
+  a copy of the GCC Runtime Library Exception along with this program;
+  see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
+  <http://www.gnu.org/licenses/>.
+-->
 <!DOCTYPE gprconfig [
 <!ENTITY % env.ent SYSTEM "env.ent"> %env.ent;
 <!ENTITY % shortcuts.ent SYSTEM "shortcuts.ent"> %shortcuts.ent;

--- a/db/compilers.xml
+++ b/db/compilers.xml
@@ -1,4 +1,27 @@
 <?xml version="1.0" ?>
+<!--
+  Knowledge base for configuring GPRBuild and GPR2 projects.
+  Copyright (C) 2006-2020, AdaCore
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  As a special exception under Section 7 of GPL version 3, you are
+  granted additional permissions described in the GCC Runtime Library
+  Exception, version 3.1, as published by the Free Software Foundation.
+
+  You should have received a copy of the GNU General Public License and
+  a copy of the GCC Runtime Library Exception along with this program;
+  see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
+  <http://www.gnu.org/licenses/>.
+-->
 <gprconfig>
   <!--  Languages that require no compiler, but can be selected through
         -config -->

--- a/db/cpp.xml
+++ b/db/cpp.xml
@@ -1,4 +1,27 @@
 <?xml version="1.0" ?>
+<!--
+  Knowledge base for configuring GPRBuild and GPR2 projects.
+  Copyright (C) 2006-2020, AdaCore
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  As a special exception under Section 7 of GPL version 3, you are
+  granted additional permissions described in the GCC Runtime Library
+  Exception, version 3.1, as published by the Free Software Foundation.
+
+  You should have received a copy of the GNU General Public License and
+  a copy of the GCC Runtime Library Exception along with this program;
+  see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
+  <http://www.gnu.org/licenses/>.
+-->
 <gprconfig>
    <!--  This package provides the default standard options for a gcc
          C++ compiler -->

--- a/db/cross.xml
+++ b/db/cross.xml
@@ -1,4 +1,27 @@
 <?xml version="1.0" ?>
+<!--
+  Knowledge base for configuring GPRBuild and GPR2 projects.
+  Copyright (C) 2006-2020, AdaCore
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  As a special exception under Section 7 of GPL version 3, you are
+  granted additional permissions described in the GCC Runtime Library
+  Exception, version 3.1, as published by the Free Software Foundation.
+
+  You should have received a copy of the GNU General Public License and
+  a copy of the GCC Runtime Library Exception along with this program;
+  see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
+  <http://www.gnu.org/licenses/>.
+-->
 <gprconfig>
    <!--  This package provides adjustments for cross compilers -->
 

--- a/db/e500v2-vx6.xml
+++ b/db/e500v2-vx6.xml
@@ -1,4 +1,27 @@
 <?xml version="1.0" ?>
+<!--
+  Knowledge base for configuring GPRBuild and GPR2 projects.
+  Copyright (C) 2006-2020, AdaCore
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  As a special exception under Section 7 of GPL version 3, you are
+  granted additional permissions described in the GCC Runtime Library
+  Exception, version 3.1, as published by the Free Software Foundation.
+
+  You should have received a copy of the GNU General Public License and
+  a copy of the GCC Runtime Library Exception along with this program;
+  see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
+  <http://www.gnu.org/licenses/>.
+-->
 <!DOCTYPE gprconfig [
 <!ENTITY % env.ent SYSTEM "env.ent"> %env.ent;
 <!ENTITY % shortcuts.ent SYSTEM "shortcuts.ent"> %shortcuts.ent;

--- a/db/e500v2-vx653.xml
+++ b/db/e500v2-vx653.xml
@@ -1,4 +1,27 @@
 <?xml version="1.0" ?>
+<!--
+  Knowledge base for configuring GPRBuild and GPR2 projects.
+  Copyright (C) 2006-2020, AdaCore
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  As a special exception under Section 7 of GPL version 3, you are
+  granted additional permissions described in the GCC Runtime Library
+  Exception, version 3.1, as published by the Free Software Foundation.
+
+  You should have received a copy of the GNU General Public License and
+  a copy of the GCC Runtime Library Exception along with this program;
+  see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
+  <http://www.gnu.org/licenses/>.
+-->
 <!DOCTYPE gprconfig [
 <!ENTITY % env.ent SYSTEM "env.ent"> %env.ent;
 <!ENTITY % shortcuts.ent SYSTEM "shortcuts.ent"> %shortcuts.ent;

--- a/db/e500v2-vx7.xml
+++ b/db/e500v2-vx7.xml
@@ -1,4 +1,27 @@
 <?xml version="1.0" ?>
+<!--
+  Knowledge base for configuring GPRBuild and GPR2 projects.
+  Copyright (C) 2006-2020, AdaCore
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  As a special exception under Section 7 of GPL version 3, you are
+  granted additional permissions described in the GCC Runtime Library
+  Exception, version 3.1, as published by the Free Software Foundation.
+
+  You should have received a copy of the GNU General Public License and
+  a copy of the GCC Runtime Library Exception along with this program;
+  see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
+  <http://www.gnu.org/licenses/>.
+-->
 <!DOCTYPE gprconfig [
 <!ENTITY % env.ent SYSTEM "env.ent"> %env.ent;
 <!ENTITY % shortcuts.ent SYSTEM "shortcuts.ent"> %shortcuts.ent;

--- a/db/e500v2-vx7r2.xml
+++ b/db/e500v2-vx7r2.xml
@@ -1,4 +1,27 @@
 <?xml version="1.0" ?>
+<!--
+  Knowledge base for configuring GPRBuild and GPR2 projects.
+  Copyright (C) 2006-2020, AdaCore
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  As a special exception under Section 7 of GPL version 3, you are
+  granted additional permissions described in the GCC Runtime Library
+  Exception, version 3.1, as published by the Free Software Foundation.
+
+  You should have received a copy of the GNU General Public License and
+  a copy of the GCC Runtime Library Exception along with this program;
+  see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
+  <http://www.gnu.org/licenses/>.
+-->
 <!DOCTYPE gprconfig [
 <!ENTITY % env.ent SYSTEM "env.ent"> %env.ent;
 <!ENTITY % shortcuts.ent SYSTEM "shortcuts.ent"> %shortcuts.ent;

--- a/db/fallback_targets.xml
+++ b/db/fallback_targets.xml
@@ -1,4 +1,27 @@
 <?xml version="1.0" ?>
+<!--
+  Knowledge base for configuring GPRBuild and GPR2 projects.
+  Copyright (C) 2006-2020, AdaCore
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  As a special exception under Section 7 of GPL version 3, you are
+  granted additional permissions described in the GCC Runtime Library
+  Exception, version 3.1, as published by the Free Software Foundation.
+
+  You should have received a copy of the GNU General Public License and
+  a copy of the GCC Runtime Library Exception along with this program;
+  see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
+  <http://www.gnu.org/licenses/>.
+-->
 
 <gprconfig>
   <fallback_targets>

--- a/db/fortran.xml
+++ b/db/fortran.xml
@@ -1,4 +1,27 @@
 <?xml version="1.0" ?>
+<!--
+  Knowledge base for configuring GPRBuild and GPR2 projects.
+  Copyright (C) 2006-2020, AdaCore
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  As a special exception under Section 7 of GPL version 3, you are
+  granted additional permissions described in the GCC Runtime Library
+  Exception, version 3.1, as published by the Free Software Foundation.
+
+  You should have received a copy of the GNU General Public License and
+  a copy of the GCC Runtime Library Exception along with this program;
+  see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
+  <http://www.gnu.org/licenses/>.
+-->
 <gprconfig>
    <!--  This package provides the default standard options for a g77
          Fortran compiler -->

--- a/db/gnat.xml
+++ b/db/gnat.xml
@@ -1,4 +1,27 @@
 <?xml version="1.0" ?>
+<!--
+  Knowledge base for configuring GPRBuild and GPR2 projects.
+  Copyright (C) 2006-2020, AdaCore
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  As a special exception under Section 7 of GPL version 3, you are
+  granted additional permissions described in the GCC Runtime Library
+  Exception, version 3.1, as published by the Free Software Foundation.
+
+  You should have received a copy of the GNU General Public License and
+  a copy of the GCC Runtime Library Exception along with this program;
+  see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
+  <http://www.gnu.org/licenses/>.
+-->
 <!DOCTYPE gprconfig [
   <!ENTITY filter_gnat '<compilers><compiler name="^GNAT$" /><compiler name="^GNAT_DOTNET$" /><compiler name="^JGNAT$" /><compiler name="^GNAT_CODEPEER$" /><compiler name="^GNAT_C$" /><compiler name="^GNAT_CCG$" /><compiler name="^GNAT_LLVM$" /></compilers>'>
 ] >

--- a/db/gprconfig.xsd
+++ b/db/gprconfig.xsd
@@ -1,6 +1,27 @@
 <?xml version="1.0"?>
 <!--
+  Knowledge base for configuring GPRBuild and GPR2 projects.
   This file contains the XML Schema for the knowledge base of gprconfig.
+  Copyright (C) 2006-2020, AdaCore
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  As a special exception under Section 7 of GPL version 3, you are
+  granted additional permissions described in the GCC Runtime Library
+  Exception, version 3.1, as published by the Free Software Foundation.
+
+  You should have received a copy of the GNU General Public License and
+  a copy of the GCC Runtime Library Exception along with this program;
+  see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
+  <http://www.gnu.org/licenses/>.
 -->
 
 <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"

--- a/db/linker.xml
+++ b/db/linker.xml
@@ -1,4 +1,27 @@
 <?xml version="1.0" ?>
+<!--
+  Knowledge base for configuring GPRBuild and GPR2 projects.
+  Copyright (C) 2006-2020, AdaCore
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  As a special exception under Section 7 of GPL version 3, you are
+  granted additional permissions described in the GCC Runtime Library
+  Exception, version 3.1, as published by the Free Software Foundation.
+
+  You should have received a copy of the GNU General Public License and
+  a copy of the GCC Runtime Library Exception along with this program;
+  see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
+  <http://www.gnu.org/licenses/>.
+-->
 <!DOCTYPE gprconfig [
    <!ENTITY gnat_pre_6.4
      '<compiler language="Ada" version="3.16" />

--- a/db/nocompiler.xml
+++ b/db/nocompiler.xml
@@ -1,4 +1,27 @@
 <?xml version="1.0" ?>
+<!--
+  Knowledge base for configuring GPRBuild and GPR2 projects.
+  Copyright (C) 2006-2020, AdaCore
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  As a special exception under Section 7 of GPL version 3, you are
+  granted additional permissions described in the GCC Runtime Library
+  Exception, version 3.1, as published by the Free Software Foundation.
+
+  You should have received a copy of the GNU General Public License and
+  a copy of the GCC Runtime Library Exception along with this program;
+  see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
+  <http://www.gnu.org/licenses/>.
+-->
 <!--  For languages with no compiler -->
 
 <gprconfig>

--- a/db/ppc-vx6.xml
+++ b/db/ppc-vx6.xml
@@ -1,4 +1,27 @@
 <?xml version="1.0" ?>
+<!--
+  Knowledge base for configuring GPRBuild and GPR2 projects.
+  Copyright (C) 2006-2020, AdaCore
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  As a special exception under Section 7 of GPL version 3, you are
+  granted additional permissions described in the GCC Runtime Library
+  Exception, version 3.1, as published by the Free Software Foundation.
+
+  You should have received a copy of the GNU General Public License and
+  a copy of the GCC Runtime Library Exception along with this program;
+  see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
+  <http://www.gnu.org/licenses/>.
+-->
 <!DOCTYPE gprconfig [
 <!ENTITY % env.ent SYSTEM "env.ent"> %env.ent;
 <!ENTITY % shortcuts.ent SYSTEM "shortcuts.ent"> %shortcuts.ent;

--- a/db/ppc-vx653.xml
+++ b/db/ppc-vx653.xml
@@ -1,4 +1,27 @@
 <?xml version="1.0" ?>
+<!--
+  Knowledge base for configuring GPRBuild and GPR2 projects.
+  Copyright (C) 2006-2020, AdaCore
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  As a special exception under Section 7 of GPL version 3, you are
+  granted additional permissions described in the GCC Runtime Library
+  Exception, version 3.1, as published by the Free Software Foundation.
+
+  You should have received a copy of the GNU General Public License and
+  a copy of the GCC Runtime Library Exception along with this program;
+  see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
+  <http://www.gnu.org/licenses/>.
+-->
 <!DOCTYPE gprconfig [
 <!ENTITY % env.ent SYSTEM "env.ent"> %env.ent;
 <!ENTITY % shortcuts.ent SYSTEM "shortcuts.ent"> %shortcuts.ent;

--- a/db/ppc-vx7.xml
+++ b/db/ppc-vx7.xml
@@ -1,4 +1,27 @@
 <?xml version="1.0" ?>
+<!--
+  Knowledge base for configuring GPRBuild and GPR2 projects.
+  Copyright (C) 2006-2020, AdaCore
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  As a special exception under Section 7 of GPL version 3, you are
+  granted additional permissions described in the GCC Runtime Library
+  Exception, version 3.1, as published by the Free Software Foundation.
+
+  You should have received a copy of the GNU General Public License and
+  a copy of the GCC Runtime Library Exception along with this program;
+  see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
+  <http://www.gnu.org/licenses/>.
+-->
 <!DOCTYPE gprconfig [
 <!ENTITY % env.ent SYSTEM "env.ent"> %env.ent;
 <!ENTITY % shortcuts.ent SYSTEM "shortcuts.ent"> %shortcuts.ent;

--- a/db/ppc-vx7r2.xml
+++ b/db/ppc-vx7r2.xml
@@ -1,4 +1,27 @@
 <?xml version="1.0" ?>
+<!--
+  Knowledge base for configuring GPRBuild and GPR2 projects.
+  Copyright (C) 2006-2020, AdaCore
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  As a special exception under Section 7 of GPL version 3, you are
+  granted additional permissions described in the GCC Runtime Library
+  Exception, version 3.1, as published by the Free Software Foundation.
+
+  You should have received a copy of the GNU General Public License and
+  a copy of the GCC Runtime Library Exception along with this program;
+  see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
+  <http://www.gnu.org/licenses/>.
+-->
 <!DOCTYPE gprconfig [
 <!ENTITY % env.ent SYSTEM "env.ent"> %env.ent;
 <!ENTITY % shortcuts.ent SYSTEM "shortcuts.ent"> %shortcuts.ent;

--- a/db/ppc64-vx7.xml
+++ b/db/ppc64-vx7.xml
@@ -1,4 +1,27 @@
 <?xml version="1.0" ?>
+<!--
+  Knowledge base for configuring GPRBuild and GPR2 projects.
+  Copyright (C) 2006-2020, AdaCore
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  As a special exception under Section 7 of GPL version 3, you are
+  granted additional permissions described in the GCC Runtime Library
+  Exception, version 3.1, as published by the Free Software Foundation.
+
+  You should have received a copy of the GNU General Public License and
+  a copy of the GCC Runtime Library Exception along with this program;
+  see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
+  <http://www.gnu.org/licenses/>.
+-->
 <!DOCTYPE gprconfig [
 <!ENTITY % env.ent SYSTEM "env.ent"> %env.ent;
 <!ENTITY % shortcuts.ent SYSTEM "shortcuts.ent"> %shortcuts.ent;

--- a/db/ppc64-vx7r2.xml
+++ b/db/ppc64-vx7r2.xml
@@ -1,4 +1,27 @@
 <?xml version="1.0" ?>
+<!--
+  Knowledge base for configuring GPRBuild and GPR2 projects.
+  Copyright (C) 2006-2020, AdaCore
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  As a special exception under Section 7 of GPL version 3, you are
+  granted additional permissions described in the GCC Runtime Library
+  Exception, version 3.1, as published by the Free Software Foundation.
+
+  You should have received a copy of the GNU General Public License and
+  a copy of the GCC Runtime Library Exception along with this program;
+  see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
+  <http://www.gnu.org/licenses/>.
+-->
 <!DOCTYPE gprconfig [
 <!ENTITY % env.ent SYSTEM "env.ent"> %env.ent;
 <!ENTITY % shortcuts.ent SYSTEM "shortcuts.ent"> %shortcuts.ent;

--- a/db/targetset.xml
+++ b/db/targetset.xml
@@ -1,4 +1,27 @@
 <?xml version="1.0" ?>
+<!--
+  Knowledge base for configuring GPRBuild and GPR2 projects.
+  Copyright (C) 2006-2020, AdaCore
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  As a special exception under Section 7 of GPL version 3, you are
+  granted additional permissions described in the GCC Runtime Library
+  Exception, version 3.1, as published by the Free Software Foundation.
+
+  You should have received a copy of the GNU General Public License and
+  a copy of the GCC Runtime Library Exception along with this program;
+  see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
+  <http://www.gnu.org/licenses/>.
+-->
 
 <gprconfig>
 

--- a/db/tricore-compilers.xml
+++ b/db/tricore-compilers.xml
@@ -1,4 +1,27 @@
 <?xml version="1.0" ?>
+<!--
+  Knowledge base for configuring GPRBuild and GPR2 projects.
+  Copyright (C) 2006-2020, AdaCore
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  As a special exception under Section 7 of GPL version 3, you are
+  granted additional permissions described in the GCC Runtime Library
+  Exception, version 3.1, as published by the Free Software Foundation.
+
+  You should have received a copy of the GNU General Public License and
+  a copy of the GCC Runtime Library Exception along with this program;
+  see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
+  <http://www.gnu.org/licenses/>.
+-->
 
 <gprconfig>
   <compiler_description>

--- a/db/tricore-configuration.xml
+++ b/db/tricore-configuration.xml
@@ -1,4 +1,27 @@
 <?xml version="1.0" ?>
+<!--
+  Knowledge base for configuring GPRBuild and GPR2 projects.
+  Copyright (C) 2006-2020, AdaCore
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  As a special exception under Section 7 of GPL version 3, you are
+  granted additional permissions described in the GCC Runtime Library
+  Exception, version 3.1, as published by the Free Software Foundation.
+
+  You should have received a copy of the GNU General Public License and
+  a copy of the GCC Runtime Library Exception along with this program;
+  see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
+  <http://www.gnu.org/licenses/>.
+-->
 
 <gprconfig>
   <configuration>

--- a/db/tricore-target.xml
+++ b/db/tricore-target.xml
@@ -1,4 +1,27 @@
 <?xml version="1.0" ?>
+<!--
+  Knowledge base for configuring GPRBuild and GPR2 projects.
+  Copyright (C) 2006-2020, AdaCore
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  As a special exception under Section 7 of GPL version 3, you are
+  granted additional permissions described in the GCC Runtime Library
+  Exception, version 3.1, as published by the Free Software Foundation.
+
+  You should have received a copy of the GNU General Public License and
+  a copy of the GCC Runtime Library Exception along with this program;
+  see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
+  <http://www.gnu.org/licenses/>.
+-->
 
 <gprconfig>
   <!-- tricore -->

--- a/db/vxworks.xml
+++ b/db/vxworks.xml
@@ -1,4 +1,27 @@
 <?xml version="1.0" ?>
+<!--
+  Knowledge base for configuring GPRBuild and GPR2 projects.
+  Copyright (C) 2006-2020, AdaCore
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  As a special exception under Section 7 of GPL version 3, you are
+  granted additional permissions described in the GCC Runtime Library
+  Exception, version 3.1, as published by the Free Software Foundation.
+
+  You should have received a copy of the GNU General Public License and
+  a copy of the GCC Runtime Library Exception along with this program;
+  see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
+  <http://www.gnu.org/licenses/>.
+-->
 <gprconfig>
   <!-- This file has been removed on 20170306. Replaced by an empty file
        for bootstrap: otherwise re-installing gprbuild on the same install

--- a/db/windres.xml
+++ b/db/windres.xml
@@ -1,4 +1,27 @@
 <?xml version="1.0" ?>
+<!--
+  Knowledge base for configuring GPRBuild and GPR2 projects.
+  Copyright (C) 2006-2020, AdaCore
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  As a special exception under Section 7 of GPL version 3, you are
+  granted additional permissions described in the GCC Runtime Library
+  Exception, version 3.1, as published by the Free Software Foundation.
+
+  You should have received a copy of the GNU General Public License and
+  a copy of the GCC Runtime Library Exception along with this program;
+  see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
+  <http://www.gnu.org/licenses/>.
+-->
 <gprconfig>
    <!--  This package provides the rules to handle Windows resource files -->
 

--- a/db/x86-vx6.xml
+++ b/db/x86-vx6.xml
@@ -1,4 +1,27 @@
 <?xml version="1.0" ?>
+<!--
+  Knowledge base for configuring GPRBuild and GPR2 projects.
+  Copyright (C) 2006-2020, AdaCore
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  As a special exception under Section 7 of GPL version 3, you are
+  granted additional permissions described in the GCC Runtime Library
+  Exception, version 3.1, as published by the Free Software Foundation.
+
+  You should have received a copy of the GNU General Public License and
+  a copy of the GCC Runtime Library Exception along with this program;
+  see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
+  <http://www.gnu.org/licenses/>.
+-->
 <!DOCTYPE gprconfig [
 <!ENTITY % env.ent SYSTEM "env.ent"> %env.ent;
 <!ENTITY % shortcuts.ent SYSTEM "shortcuts.ent"> %shortcuts.ent;

--- a/db/x86-vx7.xml
+++ b/db/x86-vx7.xml
@@ -1,4 +1,27 @@
 <?xml version="1.0" ?>
+<!--
+  Knowledge base for configuring GPRBuild and GPR2 projects.
+  Copyright (C) 2006-2020, AdaCore
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  As a special exception under Section 7 of GPL version 3, you are
+  granted additional permissions described in the GCC Runtime Library
+  Exception, version 3.1, as published by the Free Software Foundation.
+
+  You should have received a copy of the GNU General Public License and
+  a copy of the GCC Runtime Library Exception along with this program;
+  see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
+  <http://www.gnu.org/licenses/>.
+-->
 <!DOCTYPE gprconfig [
 <!ENTITY % env.ent SYSTEM "env.ent"> %env.ent;
 <!ENTITY % shortcuts.ent SYSTEM "shortcuts.ent"> %shortcuts.ent;

--- a/db/x86-vx7r2.xml
+++ b/db/x86-vx7r2.xml
@@ -1,4 +1,27 @@
 <?xml version="1.0" ?>
+<!--
+  Knowledge base for configuring GPRBuild and GPR2 projects.
+  Copyright (C) 2006-2020, AdaCore
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  As a special exception under Section 7 of GPL version 3, you are
+  granted additional permissions described in the GCC Runtime Library
+  Exception, version 3.1, as published by the Free Software Foundation.
+
+  You should have received a copy of the GNU General Public License and
+  a copy of the GCC Runtime Library Exception along with this program;
+  see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
+  <http://www.gnu.org/licenses/>.
+-->
 <!DOCTYPE gprconfig [
 <!ENTITY % env.ent SYSTEM "env.ent"> %env.ent;
 <!ENTITY % shortcuts.ent SYSTEM "shortcuts.ent"> %shortcuts.ent;

--- a/db/x86_64-vx7.xml
+++ b/db/x86_64-vx7.xml
@@ -1,4 +1,27 @@
 <?xml version="1.0" ?>
+<!--
+  Knowledge base for configuring GPRBuild and GPR2 projects.
+  Copyright (C) 2006-2020, AdaCore
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  As a special exception under Section 7 of GPL version 3, you are
+  granted additional permissions described in the GCC Runtime Library
+  Exception, version 3.1, as published by the Free Software Foundation.
+
+  You should have received a copy of the GNU General Public License and
+  a copy of the GCC Runtime Library Exception along with this program;
+  see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
+  <http://www.gnu.org/licenses/>.
+-->
 <!DOCTYPE gprconfig [
 <!ENTITY % env.ent SYSTEM "env.ent"> %env.ent;
 <!ENTITY % shortcuts.ent SYSTEM "shortcuts.ent"> %shortcuts.ent;

--- a/db/x86_64-vx7r2.xml
+++ b/db/x86_64-vx7r2.xml
@@ -1,4 +1,27 @@
 <?xml version="1.0" ?>
+<!--
+  Knowledge base for configuring GPRBuild and GPR2 projects.
+  Copyright (C) 2006-2020, AdaCore
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  As a special exception under Section 7 of GPL version 3, you are
+  granted additional permissions described in the GCC Runtime Library
+  Exception, version 3.1, as published by the Free Software Foundation.
+
+  You should have received a copy of the GNU General Public License and
+  a copy of the GCC Runtime Library Exception along with this program;
+  see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
+  <http://www.gnu.org/licenses/>.
+-->
 <!DOCTYPE gprconfig [
 <!ENTITY % env.ent SYSTEM "env.ent"> %env.ent;
 <!ENTITY % shortcuts.ent SYSTEM "shortcuts.ent"> %shortcuts.ent;


### PR DESCRIPTION
Hello.
Now that the XML files are in their own package, their license status is not crystal-clear anymore out of context.  Could you please make explicit that the license is GPL-3+ with GCC-runtime-library exception?