### PR TITLE
Support OpenBSD

### DIFF
--- a/db/compilers.xml
+++ b/db/compilers.xml
@@ -168,7 +168,7 @@
     <executable prefix="1">(.*-wrs-.*|.*-sysgo.*|.*-elf-.*|.*-eabi-.*|.*-eabispe-.*|avr-.*|.*-elinos-linux.*|.*-generic-linux-gnu-|.*mingw32.*|.*-xcoff-.*|arm-linux-androideabi-|arm-linux-gnueabi-|arm-linux-gnueabihf-|e500v2-gnu-linux-|powerpc-.*-linux.*-|.*-darwin.*-|aarch64-linux-gnu-|.*-qnx.*|.*-rtems.*)?ld</executable>
     <version>
       <external>${PREFIX}ld -v</external>
-      <grep regexp="^GNU ld.* (\S+)" group="1"></grep>
+      <grep regexp="^(GNU ld.*|LLD) (\S+)" group="2"></grep>
     </version>
     <languages>Bin_Img</languages>
     <target>

--- a/db/linker.xml
+++ b/db/linker.xml
@@ -1092,12 +1092,13 @@
     </config>
   </configuration>
 
-  <!-- linux, freebsd, Irix, QNX -->
+  <!-- linux, freebsd, Irix, OpenBSD, QNX -->
   <configuration>
     <targets>
        <target name="^.*linux.*$" />
        <target name="^.*freebsd.*$" />
        <target name="^.*irix.*$" />
+       <target name="^.*openbsd.*$" />
        <target name="^.*qnx[0-9]*$" />
     </targets>
     <config>
@@ -1130,12 +1131,13 @@
     </config>
   </configuration>
 
-  <!-- linux, freebsd, QNX -->
+  <!-- linux, freebsd, OpenBSD, QNX -->
   <configuration>
     <targets>
        <target name="^.*linux.*$" />
        <target name="^.*qnx[0-9]*$" />
        <target name="^.*freebsd.*$" />
+       <target name="^.*openbsd.*$" />
     </targets>
     <config>
    for Run_Path_Option  use ("-Wl,-z,origin,-rpath,");
@@ -1613,6 +1615,7 @@
        <target name="^.*mingw.*$" />
        <target name="^.*linux.*$" />
        <target name="^.*freebsd.*$" />
+       <target name="^.*openbsd.*$" />
        <target name="^.*-qnx[0-9]*"/>
      </targets>
     <config>
@@ -1661,6 +1664,7 @@
        <target name="^.*mingw.*$" />
        <target name="^.*linux.*$" />
        <target name="^.*freebsd.*$" />
+       <target name="^.*openbsd.*$" />
      </targets>
     <config>
    package Linker is
@@ -1697,6 +1701,7 @@
        <target name="^.*mingw.*$" />
        <target name="^.*linux.*$" />
        <target name="^.*freebsd.*$" />
+       <target name="^.*openbsd.*$" />
      </targets>
     <config>
    package Linker is


### PR DESCRIPTION
Recent versions of OpenBSD use LLD, the LLVM linker, by default.  This
linker is compatible with GNU linkers, so this commit changes the
compiler_description entry for LD so that its version regexp matches
LLD's version string.

The other linker configurations are like those used on Linux and
FreeBSD, so I added OpenBSD to the relevant target patterns.

Using this configuration, I've been able to build a wide array of Ada
tools using gprconfig and gprbuild.