### PR TITLE
This patch consists of 2 small changes.

### DIFF
--- a/db/compilers.xml
+++ b/db/compilers.xml
@@ -195,11 +195,14 @@
       <external>${PREFIX}gcc -v</external>
       <grep regexp="^[-\w]*gcc \S+ (\S+)" group="1"></grep>
     </variable>
+    <variable name="gcc_major_version">
+      <external>${PREFIX}gcc -dumpversion | cut -f1 -d.</external>
+    </variable>
     <runtimes default="default,kernel,native">
-       <directory group="default" >\.\./lib/gcc(-lib)?/$TARGET/$gcc_version/adalib/</directory>
-       <directory group="default" contents="^rts-">\.\./lib/gcc(-lib)?/$TARGET/$gcc_version/ada_object_path</directory>
-       <directory group="2" >\.\./lib/gcc(-lib)?/$TARGET/$gcc_version/rts-(.*)/adalib/</directory>
-       <directory group="1" >\.\./$TARGET/lib/gnat/(.*)/adalib/</directory>
+       <directory group="default" >\.\./lib*/gcc(-lib)?/$TARGET/($gcc_version|$gcc_major_version)/adalib/</directory>
+       <directory group="default" contents="^rts-">\.\./lib*/gcc(-lib)?/$TARGET/($gcc_version|$gcc_major_version)/ada_object_path</directory>
+       <directory group="2" >\.\./lib*/gcc(-lib)?/$TARGET/($gcc_version|$gcc_major_version)/rts-(.*)/adalib/</directory>
+       <directory group="1" >\.\./$TARGET/lib*/gnat/(.*)/adalib/</directory>
     </runtimes>
     <target>
       <external>${PREFIX}gcc -dumpmachine</external>


### PR DESCRIPTION
Many Linux distros do not give the full version in the gcc directory
structure, ie /usr/lib64/gcc/x86_64-pc-linux/7 rather than
/usr/lib64/gcc/x86_64-pc-linux/7.5.0, limiting it to only the major
verion number rather than the full version number. We therefore should
check for both.

On 64bit systems with a 32bit underlay, you cannot have the dual files
under the same directory. It is normal therefore to have 32bit systems
under .../lib and 64bit systems under .../lib64 and others. However,
gprconfig only checks .../lib. We therefore wildcard .../lib* to
ensure the Ada runtime is picked up. As the regex has a hefty path to
check, the overhead that this produces is minimal.