### PR TITLE
aarch64-apple-darwin supports shared libraries.

### DIFF
--- a/db/linker.xml
+++ b/db/linker.xml
@@ -952,7 +952,6 @@
        <target name="^erc32-elf$" />
        <target name="^leon-elf$" />
        <target name="^leon3-elf$" />
-       <target name="^aarch64-apple-darwin.*$" />
        <target name="^aarch64-elf$" />
        <target name="^arm(-none)?-eabi$" />
        <target name="^arm-apple-darwin.*$" />
@@ -1041,6 +1040,7 @@
        <target name="^i.86-.*darwin.*$" />
        <target name="^powerpc-.*darwin.*$" />
        <target name="^x86_64-.*darwin.*$" />
+       <target name="^aarch64-.*darwin.*$" />
     </targets>
     <config>
    for Library_Builder use "${GPRCONFIG_PREFIX}libexec/gprbuild/gprlib";


### PR DESCRIPTION
aarch64-apple-darwin was in the list of systems that don't support shared libraries: removed.
aarch64-apple-darwin wasn't in the list of full Darwin (MacOS) systems: added (actually, in line with the other systems in this list, the regex is `^aarch64-.*darwin.*$`, not sure what systems we're aiming at there?)