### PR TITLE
Check lib,lib32 & lib64 path and check for gcc major version only

### DIFF
--- a/db/compilers.xml
+++ b/db/compilers.xml
@@ -195,11 +195,15 @@
       <external>${PREFIX}gcc -v</external>
       <grep regexp="^[-\w]*gcc \S+ (\S+)" group="1"></grep>
     </variable>
+    <variable name="gcc_version_major">
+      <external>${PREFIX}gcc -v</external>
+      <grep regexp="^[-\w]*gcc \S+ (\d+)\.\d+\.\d+" group="1"></grep>
+    </variable>
     <runtimes default="default,kernel,native">
-       <directory group="default" >\.\./lib/gcc(-lib)?/$TARGET/$gcc_version/adalib/</directory>
-       <directory group="default" contents="^rts-">\.\./lib/gcc(-lib)?/$TARGET/$gcc_version/ada_object_path</directory>
-       <directory group="2" >\.\./lib/gcc(-lib)?/$TARGET/$gcc_version/rts-(.*)/adalib/</directory>
-       <directory group="1" >\.\./$TARGET/lib/gnat/(.*)/adalib/</directory>
+       <directory group="default" >\.\./lib(32|64)?/gcc(-lib)?/$TARGET/($gcc_version|$gcc_version_major)/adalib/</directory>
+       <directory group="default" contents="^rts-">\.\./lib(32|64)?/gcc(-lib)?/$TARGET/($gcc_version|$gcc_version_major)/ada_object_path</directory>
+       <directory group="4" >\.\./lib(32|64)?/gcc(-lib)?/$TARGET/($gcc_version|$gcc_version_major)/rts-(.*)/adalib/</directory>
+       <directory group="2" >\.\./$TARGET/lib(32|64)?/gnat/(.*)/adalib/</directory>
     </runtimes>
     <target>
       <external>${PREFIX}gcc -dumpmachine</external>


### PR DESCRIPTION
After much embarrassment, I think I have finally got this sussed. Last throw of the dice...

On 64bit systems with a 32bit underlay, you cannot have the dual
files under the same directory. It is normal therefore to have
32bit systems under .../lib and 64bit systems under .../lib64 and
others. However, gprconfig only checks .../lib. We therefore check
lib, lib32 & lib64 to ensure the Ada runtime is picked up. As the
regex has a hefty path to check, the overhead that this produces
is minimal.

Many Linux distros do not give the full version in the gcc
directory structure, ie /usr/lib64/gcc/x86_64-pc-linux/7 rather
than /usr/lib64/gcc/x86_64-pc-linux/7.5.0, limiting it to only
the major verion number rather than the full version number.
We therefore should check for both.