### PR TITLE
Archive_Builder for alpine-linux-musl on any architecture

### DIFF
--- a/db/linker.xml
+++ b/db/linker.xml
@@ -729,6 +729,18 @@
 
   <configuration>
     <targets>
+      <target name="^.*alpine-linux-musl.*$" />
+    </targets>
+    <config>
+   for Archive_Builder  use ("ar", "cr");
+   for Archive_Builder_Append_Option use ("q");
+   for Archive_Indexer  use ("ranlib");
+   for Archive_Suffix   use ".a";
+    </config>
+  </configuration>
+
+  <configuration>
+    <targets>
       <target name="^avr$" />
     </targets>
     <config>


### PR DESCRIPTION
Alpine Linux currently supports x86, x86_64, armhf, armv7, aarch64, ppc64le, and s390x architectures. This patch adds a single Archive_Builder configuration for all architectures.