### PR TITLE
Detect gcc-MAJOR compiler as well as gcc or TARGET-gcc

### DIFF
--- a/db/asm.xml
+++ b/db/asm.xml
@@ -9,7 +9,7 @@
      </compilers>
      <config>
    package Compiler is
-      for Driver            ("Asm_Cpp") use "${PATH(asm_cpp)}${PREFIX(asm_cpp)}gcc";
+      for Driver            ("Asm_Cpp") use "${PATH(asm_cpp)}${EXEC(asm_cpp)}";
       for Leading_Required_Switches ("Asm_Cpp") use
          Compiler'Leading_Required_Switches ("Asm_Cpp") &amp;
          ("-c", "-x", "assembler-with-cpp");
@@ -27,7 +27,7 @@
      </compilers>
      <config>
    package Compiler is
-      for Driver            ("Asm") use "${PATH(asm)}${PREFIX(asm)}gcc";
+      for Driver            ("Asm") use "${PATH(asm)}${EXEC(asm)}";
       for Leading_Required_Switches ("Asm") use
         Compiler'Leading_Required_Switches ("Asm") &amp;
         ("-c", "-x", "assembler");
@@ -44,7 +44,7 @@
      </compilers>
      <config>
    package Compiler is
-      for Driver            ("Asm2") use "${PATH(asm2)}${PREFIX(asm2)}gcc";
+      for Driver            ("Asm2") use "${PATH(asm2)}${EXEC(asm2)}";
       for Leading_Required_Switches ("Asm2") use
         Compiler'Leading_Required_Switches ("Asm2") &amp;
         ("-c", "-x", "assembler");

--- a/db/c.xml
+++ b/db/c.xml
@@ -14,7 +14,7 @@
      </compilers>
      <config>
    package Compiler is
-      for Driver              ("C") use "${PATH(c)}${PREFIX(c)}gcc";
+      for Driver              ("C") use "${PATH(c)}${EXEC(c)}";
    end Compiler;
      </config>
    </configuration>

--- a/db/compilers.xml
+++ b/db/compilers.xml
@@ -20,15 +20,15 @@
   <!--    GCC 3.x & 4.x (not for GNAT Pro)-->
   <compiler_description>
     <name>GCC</name>
-    <executable prefix="1">(.*-wrs-.*|.*-sysgo.*|.*-elf-.*|.*-eabi-.*|.*-eabispe-.*|avr-.*|.*-elinos-linux.*|.*-linux-gnu-|.*mingw32.*|.*-xcoff-.*|arm-linux-androideabi-|arm-linux-gnueabi-|arm-linux-gnueabihf-|e500v2-gnu-linux-|powerpc-.*-linux.*-|.*-darwin.*-)?gcc</executable>
+    <executable prefix="1">(.*-wrs-.*|.*-sysgo.*|.*-elf-.*|.*-eabi-.*|.*-eabispe-.*|avr-.*|.*-elinos-linux.*|.*-linux-gnu-|.*mingw32.*|.*-xcoff-.*|arm-linux-androideabi-|arm-linux-gnueabi-|arm-linux-gnueabihf-|e500v2-gnu-linux-|powerpc-.*-linux.*-|.*-darwin.*-)?gcc(-\d+)?</executable>
     <version>
-      <external>${PREFIX}gcc -v</external>
+      <external>$EXEC -v</external>
       <nogrep regexp="for GNAT Pro"></nogrep>
       <grep regexp="^gcc \S+ (\S+)" group="1"></grep>
     </version>
     <languages>C</languages>
     <target>
-      <external>${PREFIX}gcc -dumpmachine</external>
+      <external>$EXEC -dumpmachine</external>
       <grep regexp="[^\r\n]+"></grep>
     </target>
   </compiler_description>
@@ -105,15 +105,15 @@
   <!--  G++ compilers (not for GNAT Pro)  -->
   <compiler_description>
     <name>G++</name>
-    <executable>g\+\+</executable>
+    <executable>g\+\+(-\d+)?</executable>
     <version>
-      <external>g++ -v</external>
+      <external>$EXEC -v</external>
       <nogrep regexp="for GNAT Pro"></nogrep>
       <grep regexp="^gcc \S+ (\S+)" group="1"></grep>
     </version>
     <languages>C++</languages>
     <target>
-      <external>g++ -dumpmachine</external>
+      <external>$EXEC -dumpmachine</external>
       <grep regexp="[^\r\n]+"></grep>
     </target>
   </compiler_description>
@@ -138,14 +138,14 @@
   <!--  Assembler -->
   <compiler_description>
     <name>GCC-ASM</name>
-    <executable prefix="1">(.*-wrs-.*|.*-sysgo.*|.*-elf-.*|.*-eabi-.*|.*-eabispe-.*|avr-.*|.*-elinos-linux.*|.*-linux-gnu-|.*mingw32.*|.*-xcoff-.*|arm-linux-androideabi-|arm-linux-gnueabi-|arm-linux-gnueabihf-|e500v2-gnu-linux-|powerpc-.*-linux.*-|.*-darwin.*-|.*-qnx.*|.*-rtems.*)?gcc</executable>
+    <executable prefix="1">(.*-wrs-.*|.*-sysgo.*|.*-elf-.*|.*-eabi-.*|.*-eabispe-.*|avr-.*|.*-elinos-linux.*|.*-linux-gnu-|.*mingw32.*|.*-xcoff-.*|arm-linux-androideabi-|arm-linux-gnueabi-|arm-linux-gnueabihf-|e500v2-gnu-linux-|powerpc-.*-linux.*-|.*-darwin.*-|.*-qnx.*|.*-rtems.*)?gcc(-\d+)?</executable>
     <version>
-      <external>${PREFIX}gcc -v</external>
+      <external>$EXEC -v</external>
       <grep regexp="^gcc \S+ (\S+)" group="1"></grep>
     </version>
     <languages>Asm,Asm_Cpp,Asm2</languages>
     <target>
-      <external>${PREFIX}gcc -dumpmachine</external>
+      <external>$EXEC -dumpmachine</external>
       <grep regexp="[^\r\n]+"></grep>
     </target>
   </compiler_description>
@@ -383,14 +383,14 @@
   <!--    GFortran  -->
   <compiler_description>
     <name>GFORTRAN</name>
-    <executable>gfortran</executable>
+    <executable>gfortran(-\d+)?</executable>
     <version>
-      <external>gfortran -v</external>
+      <external>$EXEC -v</external>
       <grep regexp="^gcc \S+ (\S+)" group="1"></grep>
     </version>
     <languages>Fortran</languages>
     <target>
-      <external>gfortran -dumpmachine</external>
+      <external>$EXEC -dumpmachine</external>
       <grep regexp="[^\r\n]+"></grep>
     </target>
   </compiler_description>

--- a/db/cpp.xml
+++ b/db/cpp.xml
@@ -12,7 +12,7 @@
      </compilers>
      <config>
    package Compiler is
-      for Driver              ("C++") use "${PATH(c++)}${PREFIX(c++)}g++";
+      for Driver              ("C++") use "${PATH(c++)}${EXEC(c++)}";
    end Compiler;
      </config>
    </configuration>

--- a/db/fortran.xml
+++ b/db/fortran.xml
@@ -42,7 +42,7 @@
      </compilers>
      <config>
    package Compiler is
-      for Driver            ("Fortran") use "${PATH(fortran)}${PREFIX(fortran)}gfortran";
+      for Driver            ("Fortran") use "${PATH(fortran)}${EXEC(fortran)}";
       for Leading_Required_Switches ("Fortran") use
          Compiler'Leading_Required_Switches ("Fortran") &amp;
          ("-c", "-fno-underscoring");


### PR DESCRIPTION
On Debian, /usr/bin/gcc, /usr/bin/gcc-10 and /usr/bin/gcc-11 may
coexist (gcc being a symbolic link to, say, gcc-11).
Currently, gprconfig only detects 'gcc'.

With this patch, all three executables are detected, so 'gcc-10' can
be explicitly selected with an explicit command line filter.
Of course, 'gcc' remains the default.

I had to replace `${PREFIX(language)}gcc` and `${PREFIX}gcc` with `$EXEC` in
a few places for the suffix to be included.  Such a replacement
reduces the overall complexity (for example GCC-ASM does apparently
not need `prefix="1"` anymore) and improves the robustness against
future changes in the executable regular expression (as this merge
request).  So you may be interested in the idea more generally.

A non-default C compiler is useful during GNAT transitions.
During last one,
* The default C compiler was gcc (link to gcc-11).
* The default Ada compiler was gnatmake (driving gcc-10).
A project mixing Ada and C cannot just
`gprconfig --config=Ada --config=C`
because gprbuild would compile Ada with gcc-10 and C with gcc-11.
Such a version mismatch may result in inconsistent ABIs and a runtime
crash, so we need something like
`gprconfig --config=Ada,10.0.0 --config=C,10.0.0`.