### PR TITLE
When gprbuild checks for ar & nm, they are not found on the aarch64 linux distros.

### DIFF
--- a/db/linker.xml
+++ b/db/linker.xml
@@ -178,10 +178,10 @@
   <configuration>
     <!-- aarch64-linux - native compiler. -->
     <targets>
-      <target name="^aarch64-linux-gnu$" />
+      <target name="^aarch64(-.+)?-linux(-gnu)?$" />
     </targets>
     <hosts>
-      <host name="^aarch64-linux-gnu$" />
+      <host name="^aarch64(-.+)?-linux(-gnu)?$" />
     </hosts>
     <config>
    for Object_Lister use ("nm", "-g");
@@ -711,10 +711,10 @@
   <configuration>
     <!-- aarch64-linux - native compiler. -->
     <targets>
-      <target name="^aarch64-linux-gnu$" />
+      <target name="^aarch64(-.+)?-linux(-gnu)?$" />
     </targets>
     <hosts>
-      <host name="^aarch64-linux-gnu$" />
+      <host name="^aarch64(-.+)?-linux(-gnu)?$" />
     </hosts>
     <config>
    for Archive_Builder  use ("ar", "cr");


### PR DESCRIPTION
When gprbuild checks for ar & nm, these are found on the x86_64 systems,
however, they are not found on aarch64, and so, no static libraries are created.

ar & lm on Linux distros are checked on the expression 'aarch64-linux-gnu' or 'x86_64.*-linux.*'.

As shown, the search on aarch64 is absolute compared to x86_64.

This change modifies the aarch expression to be 'aarch64(-.*)?-linux(-gnu)?$'

This allows for a distros name & the '-gnu' part to be wholly optional and as such will trigger on a target name of 'aarch64-suse-linux'.

This is more strict than the x86_64 expression & so is more unlikely to be fired for other names. Perhaps the x86_64 expression should be updated to somewhat mirror this aarch64 change.